### PR TITLE
Fix console spam from database connection failures

### DIFF
--- a/src/main/java/com/minekartastudio/kartaauctionhouse/KartaAuctionHouse.java
+++ b/src/main/java/com/minekartastudio/kartaauctionhouse/KartaAuctionHouse.java
@@ -56,6 +56,11 @@ public class KartaAuctionHouse extends JavaPlugin {
 
         // 3. Initialize Database
         databaseManager = new DatabaseManager(this, configManager);
+        if (!databaseManager.isDatabaseConnected()) {
+            getLogger().severe("Disabling KartaAuctionHouse due to database connection failure.");
+            getServer().getPluginManager().disablePlugin(this);
+            return;
+        }
         AuctionStorage auctionStorage = new MySqlAuctionStorage(this, databaseManager);
         MailboxStorage mailboxStorage = new MySqlMailboxStorage(this, databaseManager);
         TransactionStorage transactionStorage = new MySqlTransactionStorage(this, databaseManager);

--- a/src/main/java/com/minekartastudio/kartaauctionhouse/storage/sql/DatabaseManager.java
+++ b/src/main/java/com/minekartastudio/kartaauctionhouse/storage/sql/DatabaseManager.java
@@ -84,10 +84,14 @@ public class DatabaseManager {
     }
 
     public Connection getConnection() throws SQLException {
-        if (dataSource == null) {
+        if (!isDatabaseConnected()) {
             throw new SQLException("Database source is not available.");
         }
         return dataSource.getConnection();
+    }
+
+    public boolean isDatabaseConnected() {
+        return dataSource != null && !dataSource.isClosed();
     }
 
     public ExecutorService getExecutor() {


### PR DESCRIPTION
The plugin was continuously trying to access the database every 30 seconds via a scheduled task, even when the initial database connection had failed. This caused repeated `SQLException` stack traces to be printed to the console.

This commit introduces a check after database initialization. If the connection to the database was not successful, the plugin will now disable itself. This prevents the scheduled task from running and stops the console spam.

Changes:
- Added `isDatabaseConnected()` method to `DatabaseManager` to provide a clear way to check the database status.
- Modified `KartaAuctionHouse` main class to check `isDatabaseConnected()` after initialization and disable the plugin if it returns false.